### PR TITLE
Fix dashboard logger transform_target check

### DIFF
--- a/pycaret/loggers/dashboard_logger.py
+++ b/pycaret/loggers/dashboard_logger.py
@@ -270,7 +270,7 @@ class DashboardLogger:
                         for logger in self.loggers
                         if hasattr(logger, "remote")
                     ]
-                    if experiment.transform_target_param:
+                    if getattr(experiment, "transform_target_param", False):
                         train_transform_path = os.path.join(
                             tmpdir, "Train_transform.csv"
                         )
@@ -291,7 +291,7 @@ class DashboardLogger:
                     train_path = os.path.join(tmpdir, "Dataset.csv")
                     experiment.train.to_csv(train_path)
                     [logger.log_artifact(train_path, "data") for logger in self.loggers]
-                    if experiment.transform_target_param:
+                    if getattr(experiment, "transform_target_param", False):
                         train_transform_path = os.path.join(
                             tmpdir, "Dataset_transform.csv"
                         )


### PR DESCRIPTION
## Summary
- avoid AttributeError in dashboard logger when running unsupervised experiments

## Testing
- `pytest -k dashboard_logger -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683f4edac324832fa9643eea4a577bff